### PR TITLE
Better platform support

### DIFF
--- a/VASharp.Tests/DrmDisplayTests.cs
+++ b/VASharp.Tests/DrmDisplayTests.cs
@@ -17,8 +17,9 @@ namespace VASharp.Tests
         {
             using var file = File.Open("test.txt", FileMode.Create);
 
-            Assert.Throws<ArgumentNullException>(() => new DrmDisplay(null, NullLogger<DrmDisplay>.Instance));
-            Assert.Throws<ArgumentNullException>(() => new DrmDisplay(file, null));
+            Assert.Throws<ArgumentNullException>(() => new DrmDisplay(null, new VAOptions(), NullLogger<DrmDisplay>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new DrmDisplay(file, null, NullLogger<DrmDisplay>.Instance));
+            Assert.Throws<ArgumentNullException>(() => new DrmDisplay(file, new VAOptions(), null));
         }
 
         /// <summary>
@@ -29,7 +30,7 @@ namespace VASharp.Tests
         public void Constructor_ThrowsOnInvalidFile()
         {
             using var file = File.Open("test.txt", FileMode.Create);
-            var ex = Assert.Throws<VAException>(() => new DrmDisplay(file, NullLogger<DrmDisplay>.Instance));
+            var ex = Assert.Throws<VAException>(() => new DrmDisplay(file, new VAOptions(), NullLogger<DrmDisplay>.Instance));
             Assert.Equal("invalid VADisplay", ex.Message);
         }
 
@@ -41,7 +42,7 @@ namespace VASharp.Tests
         public void Constructor_OpensDisplay()
         {
             using var file = File.Open("/dev/dri/renderD128", FileMode.Open, FileAccess.ReadWrite);
-            using var display = new DrmDisplay(file, NullLogger<DrmDisplay>.Instance);
+            using var display = new DrmDisplay(file, new VAOptions(), NullLogger<DrmDisplay>.Instance);
             
             Assert.Equal(new Version(1, 20), display.Version);
             var s = display.VendorString;

--- a/VASharp.Tests/Win32DisplayTests.cs
+++ b/VASharp.Tests/Win32DisplayTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Logging.Abstractions;
-using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Xunit;
 
@@ -7,20 +6,14 @@ namespace VASharp.Tests
 {
     public class Win32DisplayTests
     {
-        public Win32DisplayTests()
+        private readonly VAOptions options = new VAOptions()
         {
             // For the time being, hardcode the paths to:
             // - The va.dll and va_win32.dll libraries which can be installed via vcpkg
             // - The drivers which can be downloaded at https://www.nuget.org/packages/Microsoft.Direct3D.VideoAccelerationCompatibilityPack/
-            NativeLibrary.Load(
-                Path.GetFullPath("../../../../vcpkg_installed/x64-windows/bin/va.dll"));
-            NativeLibrary.Load(
-                Path.GetFullPath(@"../../../../vcpkg_installed/x64-windows/bin/va_win32.dll"));
-
-            Environment.SetEnvironmentVariable(
-                "LIBVA_DRIVERS_PATH",
-                Path.GetFullPath("../../../../"));
-        }
+            LibraryPath = Path.GetFullPath("../../../../vcpkg_installed/x64-windows/bin/"),
+            DriverPath = Path.GetFullPath("../../../../"),
+        };
 
         /// <summary>
         /// The <see cref="DrmDisplay.Win32Display(ILogger{Win32Display})"/> constructor can be used to
@@ -29,7 +22,7 @@ namespace VASharp.Tests
         [SkippableFact, SupportedOSPlatform("windows")]
         public void Constructor_OpensDisplay()
         {
-            using var display = new Win32Display(NullLogger<Win32Display>.Instance);
+            using var display = new Win32Display(this.options, NullLogger<Win32Display>.Instance);
             Assert.Equal("Mesa Gallium driver 23.3.0-devel for D3D12 (Intel(R) UHD Graphics)", display.VendorString);
         }
     }

--- a/VASharp/DrmDisplay.cs
+++ b/VASharp/DrmDisplay.cs
@@ -23,10 +23,13 @@ namespace VASharp
             : base(logger)
         {
             this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
-            
-            this.display = DrmMethods.vaGetDisplayDRM((int)stream.SafeFileHandle.DangerousGetHandle());
 
+#if WITHOUT_DRM
+            throw new NotSupportedException("DrmDisplay is not supported on this build of VASharp.");
+#else
+            this.display = DrmMethods.vaGetDisplayDRM((int)stream.SafeFileHandle.DangerousGetHandle());
             this.Initialize();
+#endif
         }
 
         /// <inheritdoc/>

--- a/VASharp/DrmDisplay.cs
+++ b/VASharp/DrmDisplay.cs
@@ -16,11 +16,16 @@ namespace VASharp
         /// Initializes a new instance of the <see cref="DrmDisplay"/> class.
         /// </summary>
         /// <param name="stream">
-        /// A <see cref="Stream"/> which represents the DRM GPU, such as <c>/dev/dri/renderD128</c></param>
-        /// <param name="logger"></param>
-        /// <exception cref="ArgumentNullException"></exception>
-        public DrmDisplay(FileStream stream, ILogger<DrmDisplay> logger)
-            : base(logger)
+        /// A <see cref="Stream"/> which represents the DRM GPU, such as <c>/dev/dri/renderD128</c>
+        /// </param>
+        /// <param name="options">
+        /// Options for the Video Acceleration library.
+        /// </param>
+        /// <param name="logger">
+        /// The logger to use for this display.
+        /// </param>
+        public DrmDisplay(FileStream stream, VAOptions options, ILogger<DrmDisplay> logger)
+            : base(options, logger)
         {
             this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
 

--- a/VASharp/VAOptions.cs
+++ b/VASharp/VAOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace VASharp
+{
+    /// <summary>
+    /// Provides options for the Video Acceleration API.
+    /// </summary>
+    public record VAOptions
+    {
+        /// <summary>
+        /// Gets or sets the path to the directory in which the va library is located.
+        /// </summary>
+        public string? LibraryPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the path to the director in which the va drivers are located.
+        /// </summary>
+        public string? DriverPath { get; set; }
+    }
+}

--- a/VASharp/VASharp.csproj
+++ b/VASharp/VASharp.csproj
@@ -1,6 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Depending on the build platform, not all libva backends may be available:
+         - Define WITHOUT_DRM if DrmMethods does not exist
+         - Define WITHOUT_WIN32 if Win32Methods does not exist
+    -->
+    <DefineConstants Condition="!Exists('$(MSBuildProjectDirectory)/Native/DrmMethods.cs')">$(DefineConstants);WITHOUT_DRM</DefineConstants>
+    <DefineConstants Condition="!Exists('$(MSBuildProjectDirectory)/Native/Win32Methods.cs')">$(DefineConstants);WITHOUT_WIN32</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/VASharp/Win32Display.cs
+++ b/VASharp/Win32Display.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using VASharp.Native;
 
@@ -12,12 +14,15 @@ namespace VASharp
         /// <summary>
         /// Initializes a new instance of the <see cref="Win32Display"/> class.
         /// </summary>
+        /// <param name="options">
+        /// Options for the Video Accelleration library.
+        /// </param>
         /// <param name="logger">
         /// The logger to use for this display.
         /// </param>
         [SupportedOSPlatform("windows")]
-        public Win32Display(ILogger<Win32Display> logger)
-            : base(logger)
+        public Win32Display(VAOptions options, ILogger<Win32Display> logger)
+            : base(options, logger)
         {
 #if WITHOUT_WIN32
             throw new NotSupportedException("Win32Display is not supported on this build of VASharp.");
@@ -26,6 +31,17 @@ namespace VASharp
 
             this.Initialize();
 #endif
+        }
+
+        protected override nint LibraryResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+        {
+            // On Windows, try to load "va_win32.dll" in LibraryPath, if one was specified.
+            if (libraryName == "va_win32" && this.options.LibraryPath != null && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return NativeLibrary.Load(Path.Combine(this.options.LibraryPath, "va_win32.dll"));
+            }
+
+            return base.LibraryResolver(libraryName, assembly, searchPath);
         }
     }
 }

--- a/VASharp/Win32Display.cs
+++ b/VASharp/Win32Display.cs
@@ -19,9 +19,13 @@ namespace VASharp
         public Win32Display(ILogger<Win32Display> logger)
             : base(logger)
         {
+#if WITHOUT_WIN32
+            throw new NotSupportedException("Win32Display is not supported on this build of VASharp.");
+#else
             this.display = Win32Methods.vaGetDisplayWin32(null);
 
             this.Initialize();
+#endif
         }
     }
 }


### PR DESCRIPTION
- Support building DrmDisplay and Win32Display without backend support
- Use VAOptions to allow callers to specify path to native libraries